### PR TITLE
Steam Rich Presence

### DIFF
--- a/src-tauri/src/steam/mod.rs
+++ b/src-tauri/src/steam/mod.rs
@@ -128,6 +128,9 @@ impl Steam {
 		lazy_static::initialize(&DOWNLOADS);
 		std::thread::spawn(Downloads::watchdog);
 
+		steam!().client().friends().set_rich_presence("steam_display", Some("#Status_Generic"));
+		steam!().client().friends().set_rich_presence("generic", Some("In gmpublisher"));
+
 		if app_data!().settings.read().gmod.is_none() {
 			app_data!().send();
 		}


### PR DESCRIPTION
Simple and nice addition. 
I've noticed that gmpublisher, because of the way it works, makes Steam think that Garry's Mod is open at moment. 
So It would be nice if we show that user is in gmpublisher instead of just gmod

![изображение](https://github.com/user-attachments/assets/a3bb65a6-b71e-422c-b3fd-e0dc50b57af2)

Not sure if I put code in right place, but that's not a big deal