### PR TITLE
fix: Settings parent directory not being made

### DIFF
--- a/src-tauri/src/appdata.rs
+++ b/src-tauri/src/appdata.rs
@@ -148,6 +148,10 @@ impl Settings {
 	}
 
 	pub fn save(&self) -> Result<(), anyhow::Error> {
+		if let Some(parent) = (&*APP_SETTINGS_PATH).parent() {
+			std::fs::create_dir_all(parent)?;
+		}
+
 		Ok(serde_json::ser::to_writer(File::create(&*APP_SETTINGS_PATH)?, self)?)
 	}
 


### PR DESCRIPTION
Fixes the settings directory not being saved
This fixes an issue with the app crashing on Linux - unsure why this is not happening anywhere else?