### PR TITLE
Fix Default Ignore List Display

### DIFF
--- a/src-tauri/src/appdata.rs
+++ b/src-tauri/src/appdata.rs
@@ -312,8 +312,7 @@ impl<R: tauri::Runtime> tauri::plugin::Plugin<R> for Plugin {
 		sanitized.sanitize();
 		*app_data!().settings.write() = sanitized;
 
-		// Trim off nul byte
-		let mut default_ignore: Vec<String> = crate::gma::DEFAULT_IGNORE.iter().map(|x| x[0..x.len() - 1].to_string()).collect();
+		let mut default_ignore: Vec<String> = crate::gma::DEFAULT_IGNORE.iter().map(|x| x.to_string()).collect();
 		default_ignore.sort();
 
 		app_data!().open_count.increment();


### PR DESCRIPTION
The `Ignored File Patterns` list in the Prepare Publish modal was showing truncated patterns (e.g. `.git/` instead of `.git/*`, `*.ps` instead of `*.psd`) because every pattern had its last character stripped before being drawn.

That was correct when globs were nul terminated when using the  `globbers!` macro. After commit 64f0464, globs are plain strings with no trailing NUL byte, so the trim was cutting off a real character.