### PR TITLE
Fix a few obvious edge cases

### DIFF
--- a/app/components/ContextMenu.svelte
+++ b/app/components/ContextMenu.svelte
@@ -9,8 +9,8 @@
 		for (let x = 0; x < mutations.length; x++) {
 			const mutation = mutations[x];
 			if (mutation.removedNodes) {
-				for (let i = 0; i < mutation.removedNodes; i++) {
-					const node = mutation[i];
+				for (let i = 0; i < mutation.removedNodes.length; i++) {
+					const node = mutation.removedNodes[i];
 					if (contextRegistry.has(node)) {
 						contextRegistry.delete(node);
 					}

--- a/app/components/PreparePublish.svelte
+++ b/app/components/PreparePublish.svelte
@@ -128,7 +128,7 @@
 		const chosen = [];
 		tagChoiceContainer.querySelectorAll(':scope > .tag-choice').forEach((choice, i) => {
 			if (choice.value !== 'default') {
-				if (chosen.findIndex(choice => choice === choice.value) !== -1) {
+				if (chosen.findIndex(chosenChoice => chosenChoice === choice.value) !== -1) {
 					choice.value = 'default';
 					chosen[i] = null;
 				} else {

--- a/src-tauri/msi/msi.wxs
+++ b/src-tauri/msi/msi.wxs
@@ -80,7 +80,7 @@
 				<RegistryValue Root="HKLM" Key="SOFTWARE\Classes\Applications\gmpublisher\SupportedTypes" Name=".gma" Value="" Type="string" />
 				<RegistryValue Root="HKLM" Key="SOFTWARE\Classes\Applications\gmpublisher\shell\open" Name="FriendlyAppName" Value="gmpublisher" Type="string" />
 
-				<RegistryValue Root="HKLM" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\gmpublisher" Value="[!gmpublisher]" Type="string" />
+				<RegistryValue Root="HKLM" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\gmpublisher" Value="[!EXE]" Type="string" />
 				<RegistryValue Root="HKLM" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\gmpublisher" Name="Path" Value="[INSTALLDIR]" Type="string" />
 			</Component>
 		</DirectoryRef>

--- a/src-tauri/src/game_addons.rs
+++ b/src-tauri/src/game_addons.rs
@@ -100,12 +100,10 @@ impl GameAddons {
 			.into_iter()
 			.rev()
 		{
-			match id.checked_add(char::to_digit(char, 10).unwrap() as u64) {
+			let digit = char::to_digit(char, 10).unwrap() as u64;
+			match id.checked_mul(10).and_then(|id| id.checked_add(digit)) {
 				None => return 0,
-				Some(id_op) => match 10_u64.checked_mul(id_op) {
-					None => return 0,
-					Some(id_op) => id = id_op,
-				},
+				Some(id_op) => id = id_op,
 			}
 		}
 		id
@@ -188,7 +186,7 @@ impl GameAddons {
 				let id = GameAddons::extract_suffix_ws_id(file_name);
 
 				tx_addons_metadata
-					.send((path, if id == 0 { None } else { Some(PublishedFileId(id / 10)) }))
+					.send((path, if id == 0 { None } else { Some(PublishedFileId(id)) }))
 					.unwrap();
 			}
 		});

--- a/src-tauri/src/steam/publishing.rs
+++ b/src-tauri/src/steam/publishing.rs
@@ -165,7 +165,7 @@ impl From<WorkshopIcon> for PathBuf {
 			WorkshopIcon::Default => {
 				let mut path = app_data!().temp_dir().to_owned();
 				path.push("gmpublisher_default_icon.png");
-				if !path.is_file() && path.metadata().map(|metadata| metadata.len()).unwrap_or(0) != WORKSHOP_DEFAULT_ICON.len() as u64 {
+				if !path.is_file() || path.metadata().map(|metadata| metadata.len()).unwrap_or(0) != WORKSHOP_DEFAULT_ICON.len() as u64 {
 					std::fs::write(&path, WORKSHOP_DEFAULT_ICON).expect("Failed to write default icon to temp directory!");
 				}
 				path

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,7 +22,12 @@ console.log('production', production);
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
-	plugins: [svelte()],
+	plugins: [svelte({
+		compilerOptions: {
+			// enable run-time checks when not in production
+			dev: !production
+		}
+	})],
 
 	// Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
 	//
@@ -43,10 +48,6 @@ export default defineConfig(async () => ({
 		inlineDynamicImports: true,
 		outDir: "../dist",
 		rollupOptions: {
-			compilerOptions: {
-				// enable run-time checks when not in production
-				dev: !production
-			},
 			input: {
 				app: './app/index.html',
 			},


### PR DESCRIPTION
Couple of small obvious fixes:

- clean up removed-node and duplicate tag checks in the publish UI
- fix stale ids/options in addon, MSI, and Vite paths

Checked with `npm run build` and `cargo check`.