### PR TITLE
Addon Size Analyzer webkit / DPI issues

### DIFF
--- a/app/pages/AddonSizeAnalyzer.svelte
+++ b/app/pages/AddonSizeAnalyzer.svelte
@@ -85,7 +85,7 @@
 			elem.classList.add('tag', tag);
 			document.body.appendChild(elem);
 
-			const color = window.getComputedStyle(elem, 'before')?.getPropertyValue('background-color');
+			const color = window.getComputedStyle(elem, '::before')?.getPropertyValue('background-color');
 			tagColors[tag] = !!color ? color : null;
 
 			elem.remove();

--- a/app/pages/AddonSizeAnalyzer.svelte
+++ b/app/pages/AddonSizeAnalyzer.svelte
@@ -308,6 +308,7 @@
 		}
 
 		if (verticalText) {
+			tagsCtx.save();
 			tagsCtx.translate(x, y);
 				tagsCtx.rotate(canvasRotation);
 			tagsCtx.translate(-x, -y);
@@ -321,7 +322,7 @@
 		tagsCtx.fillText(tag, x, y);
 
 		if (verticalText) {
-			tagsCtx.setTransform(1, 0, 0, 1, 0, 0);
+			tagsCtx.restore();
 		}
 	}
 

--- a/app/pages/AddonSizeAnalyzer.svelte
+++ b/app/pages/AddonSizeAnalyzer.svelte
@@ -317,7 +317,7 @@
 		tagsCtx.font = textSize + 'px sans-serif';
 		tagsCtx.fillStyle = '#fff';
 		tagsCtx.strokeStyle = '#000';
-		tagsCtx.lineWidth = Math.min(Math.max(Math.ceil(textSize * 0.2), 4), (14 / 1920) * window.outerWidth);
+		tagsCtx.lineWidth = Math.min(Math.max(Math.ceil(textSize * 0.2), 4), (14 / 1920) * window.innerWidth);
 		tagsCtx.strokeText(tag, x, y);
 		tagsCtx.fillText(tag, x, y);
 


### PR DESCRIPTION
Hi, this fixes some issues in the Size Analyzer when rendering with webkit (macOS & presumably Linux), and fixes a platform-independent issue with labels on high-dpi displays (previously they'd jump around after moving your cursor if you had vertical categories).

The issues were:

1. Webkit doesn't expose a value for outerWidth in the app, and so label stroke was always the default 1px. Changed to window.innerWidth which has a ~consistent value across the 3 platforms.
2. Webkit requires a leading colon for the tag colour's getComputedStyle (apparently WebView2 allows either).
3. Tag transform is set to 1x1 scale for vertical categories, overriding the actual display scale when placing labels. Changed to save and then restore the scale.

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/081bd449-45ec-44f1-8ceb-8772a4d289af" />

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/6335f475-4b8c-4ddf-960b-723fae94908e" />
