### PR TITLE
Direct stars to the repo instead of the deprecated stargazers view

### DIFF
--- a/app/components/NavSidebar.svelte
+++ b/app/components/NavSidebar.svelte
@@ -66,7 +66,7 @@
 	<div id="credits" slot="footer">
 		<!--<img src="/img/logo.svg" alt="Logo" id="logo"/>--><Logo/><br>
 		gmpublisher v{AppData.version} by Billy<br>
-		<a tabindex="-1" href="https://github.com/WilliamVenner/gmpublisher/stargazers" target="_blank">{$_('github_star')}</a>&nbsp;🤩
+		<a tabindex="-1" href="https://github.com/WilliamVenner/gmpublisher/" target="_blank">{$_('github_star')}</a>&nbsp;🤩
 	</div>
 </Sidebar>
 


### PR DESCRIPTION
Hi, I was messing around with some stuff and realised the stargazers page is now a 404 for non-maintainers across GitHub. If you want, this changes the Star on GitHub button to open the repo instead

https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/